### PR TITLE
feat: 로그인 여부에 따라 사용자 정보를 달리 보이게 만듦 & 캘린더에 헤더 임시 연결

### DIFF
--- a/BE/src/main/resources/static/src/fragments/header/header.html
+++ b/BE/src/main/resources/static/src/fragments/header/header.html
@@ -9,7 +9,8 @@
     <link rel="stylesheet" href="/dist/output.css" />
   </head>
   <body>
-    <header>
+<!--    th:fragment="템플릿 조각 이름" -> th:fragment="header" -> header라는 템플릿 조각을 만든 것-->
+    <header th:fragment="header">
       <div
         class="flex justify-between border-b border-b-slate-300 px-4 lg:px-12 py-6"
       >
@@ -31,22 +32,18 @@
         <!-- 로그인 영역 -->
         <div class="flex items-center text-center">
           <!-- 로그인한 경우 -->
-          <a
-            th:if="${session.user}"
-            href="#"
-            class="flex-row items-center text-center"
-            ><img
+          <a href="#" class="flex-row items-center text-center" th:if="${#session != null}">
+            <img
               src="/src/assets/images/user.svg"
               alt="로그인 계정 이미지"
               class="h-12 sm:h-16"
             />
-            <div class="font-semibold" th:text="${session.user.name}">
-              김관리
-            </div></a
-          >
+<!--            로그인 사용자명-->
+            <div class="font-semibold" th:text="${MemberLogin.memberName}"></div>
+          </a>
 
           <!-- 로그인 하지 않은 경우 -->
-          <a th:unless="${session.user}" href="#" class="flex items-center">
+          <a href="#" class="flex items-center" th:if="${#session == null}">
             <button
               type="button"
               class="text-white bg-sky-400 hover:bg-sky-600 px-2 sm:px-5 py-1 sm:py-2.5 rounded-xl font-semibold"

--- a/BE/src/main/resources/static/src/pages/calendar/calendar.html
+++ b/BE/src/main/resources/static/src/pages/calendar/calendar.html
@@ -13,7 +13,8 @@
     <link rel="stylesheet" th:href="@{/dist/output.css}" />
   </head>
   <body>
-    <main id="calendar" class="container mx-auto flex justify-evenly flex-col relative">
+  <div th:replace="~{/fragments/header/header.html :: header}"></div>
+  <main id="calendar" class="container mx-auto flex justify-evenly flex-col relative">
       <header id="header-container" class="flex w-full items-center justify-center">
         <button id="today-btn">오늘</button>
         <select


### PR DESCRIPTION
## PR 내용 (구현 사항 등)

- [x] 기능 추가 :  로그인 여부에 따라 사용자 정보를 달리 보이게 만듦 
- [ ] 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [x] 기타 : 캘린더에 헤더 임시 연결


<br>

## 특이사항

- 캘린더 페이지에 헤더 임시로 연결 해뒀습니다.
